### PR TITLE
Ensure teen actor career shows active icon

### DIFF
--- a/Adult Jobs for Teens/Get Famous/545AC67A!00996B98!000000000002E2CF.career_Adult_Active_ActorCareer.SimData.xml
+++ b/Adult Jobs for Teens/Get Famous/545AC67A!00996B98!000000000002E2CF.career_Adult_Active_ActorCareer.SimData.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SimData version="0x00000101" u="0x0000001B">
+  <Instances>
+    <I name="career_Adult_Active_ActorCareer" schema="Career" type="Object">
+      <V name="build_buy_info" variant="0xC1A03855" />
+      <V name="call_costar_interaction" variant="0xF8CBBF4C">
+        <T type="TableSetReference">193086</T>
+      </V>
+      <V name="cancel_audition_interaction" variant="0xF8CBBF4C">
+        <T type="TableSetReference">193016</T>
+      </V>
+      <V name="cancel_gig_interaction" variant="0xF8CBBF4C">
+        <T type="TableSetReference">193024</T>
+      </V>
+      <T name="career_category">1</T>
+      <T name="career_panel_type">7</T>
+      <V name="find_audition_interaction" variant="0xF8CBBF4C">
+        <T type="TableSetReference">193018</T>
+      </V>
+      <V name="hire_agent_interaction" variant="0xF8CBBF4C">
+        <T type="TableSetReference">195273</T>
+      </V>
+      <V name="reputation_stat" variant="0xC1A03855" />
+      <T name="show_ideal_mood">1</T>
+      <T name="start_track">189131</T>
+    </I>
+  </Instances>
+  <Schemas>
+    <Schema name="Career" schema_hash="0xC80851A2">
+      <Columns>
+        <Column name="build_buy_info" type="Variant" flags="0x00000000" />
+        <Column name="call_costar_interaction" type="Variant" flags="0x00000000" />
+        <Column name="cancel_audition_interaction" type="Variant" flags="0x00000000" />
+        <Column name="cancel_gig_interaction" type="Variant" flags="0x00000000" />
+        <Column name="career_category" type="Int64" flags="0x00000000" />
+        <Column name="career_panel_type" type="Int64" flags="0x00000000" />
+        <Column name="find_audition_interaction" type="Variant" flags="0x00000000" />
+        <Column name="hire_agent_interaction" type="Variant" flags="0x00000000" />
+        <Column name="reputation_stat" type="Variant" flags="0x00000000" />
+        <Column name="show_ideal_mood" type="Boolean" flags="0x00000000" />
+        <Column name="start_track" type="TableSetReference" flags="0x00000000" />
+      </Columns>
+    </Schema>
+  </Schemas>
+</SimData>

--- a/Adult Jobs for Teens/Get Famous/73996BEB!0000001B!000000000002E2CF.career_Adult_Active_ActorCareer.CareerTuning.xml
+++ b/Adult Jobs for Teens/Get Famous/73996BEB!0000001B!000000000002E2CF.career_Adult_Active_ActorCareer.CareerTuning.xml
@@ -689,7 +689,7 @@
       <T n="take_pto_button_text">0xA0C11A0D<!--Take PTO--></T>
     </U>
   </U>
-  <E n="career_panel_type">AGENT_BASED_CAREER</E>
+  <E n="career_panel_type">ACTIVE_GIG_BASED_CAREER</E>
   <T n="career_rabbit_hole">234354<!--careerRabbitHole--></T>
   <U n="career_story_progression">
     <V n="joining" t="enabled">


### PR DESCRIPTION
## Summary
- Mark actor career as an active gig-based career so teens see the active icon
- Sync SimData career panel type with tuning for actor career

## Testing
- `xmllint --noout 'Adult Jobs for Teens/Get Famous/73996BEB!0000001B!000000000002E2CF.career_Adult_Active_ActorCareer.CareerTuning.xml' 'Adult Jobs for Teens/Get Famous/545AC67A!00996B98!000000000002E2CF.career_Adult_Active_ActorCareer.SimData.xml'`

------
https://chatgpt.com/codex/tasks/task_e_68a5c8cb5b548325ad9f7a6f94bf222e